### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ source env/bin/activate
 pip3 install -r requirements.txt
 ```
 
+Install latest version (may be unstable) from GitHub
+
+```
+pip install git+https://github.com/roboflow-ai/roboflow-python.git
+```
+
 ## Quickstart
 
 ```python


### PR DESCRIPTION
The README stated that there are **three** ways to install Roboflow but only two are shown. I believe you also wanted to show how to install the latest version from GitHub, so I've added it to the README.