### PR TITLE
don't pass `local` keyword arg to `ClassificationModel`

### DIFF
--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -60,7 +60,6 @@ class Version:
                     self.id,
                     self.name,
                     version_without_workspace,
-                    local=local,
                 )
             else:
                 self.model = None

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -60,6 +60,7 @@ class Version:
                     self.id,
                     self.name,
                     version_without_workspace,
+                    local=local
                 )
             else:
                 self.model = None

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -60,7 +60,7 @@ class Version:
                     self.id,
                     self.name,
                     version_without_workspace,
-                    local=local
+                    local=local,
                 )
             else:
                 self.model = None

--- a/roboflow/models/classification.py
+++ b/roboflow/models/classification.py
@@ -13,7 +13,7 @@ from roboflow.util.prediction import PredictionGroup
 
 
 class ClassificationModel:
-    def __init__(self, api_key, id, name=None, version=None):
+    def __init__(self, api_key, id, name=None, version=None, local=False):
         """
         :param api_key: private roboflow api key
         :param id: the workspace/project id


### PR DESCRIPTION
this fixes https://github.com/roboflow-ai/roboflow-bugtracker/issues/227

I tested this by running the following code from the bug report locally:
```
from roboflow import Roboflow
rf = Roboflow(api_key="2lwa7Lfz2bFil1jbFOF5")
project = rf.workspace("mohamed-traore-w4h8y").project("bug-test-pvmy6")
dataset = project.version(1).download("multiclass")
```

After removing the local keyword arg, it downloaded the dataset correctly.  