### PR TITLE
Fix crashed github action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: 🛎️ Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: 🐍 Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
# Description

Trying to fix failed GitHub action run with error

```
The process '/usr/bin/git' failed with exit code 1
````

See [this one](https://github.com/roboflow-ai/roboflow-python/actions/runs/3055449080) 