### PR TITLE
Define model before using it in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ project.versions()
 project.upload("UPLOAD_IMAGE.jpg")
 
 # Retrieve the model of a specific project
-project.version("1").model
+model = project.version("1").model
 
 # predict on a local image
 prediction = model.predict("YOUR_IMAGE.jpg")


### PR DESCRIPTION
# Description

The example code in the README doesn't define `model` before using it.