### PR TITLE
Batch name upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ python -m unittest
 ### Contributing
 
 1. Increment the pip package minor version number in `setup.py`
-1. Manually add any new dependencies to `requirements.txt` and list of dependencies in `setup.py` (Be careful not to overwrite any packages that might screw up backwards dependencies for object detection, etc.)
+1. Manually add any new dependencies to `requirements.txt` with a version such as `chardet==4.0.0` and list of dependencies in `setup.py` (Be careful not to overwrite any packages that might screw up backwards dependencies for object detection, etc.)
 
 ### Code Quality
 

--- a/README.md
+++ b/README.md
@@ -145,13 +145,7 @@ pip3 install -e ".[dev]"
 
 ### Testing
 
-You need to have the following `env` variables defined. If using docker along with the `.env` file, these will be automatically defined.
-
-```
-ROBOFLOW_API_KEY="<YOUR_ROBOFLOW_PRIVATE_API_KEY>"
-PROJECT_NAME="<YOUR_PROJECT_NAME>"
-PROJECT_VERSION="1"
-```
+Make sure you have your `virtualenv` spun up before running tests. Execute the `unittest` command at the `/root` level directory.
 
 Run tests:
 

--- a/roboflow/config.py
+++ b/roboflow/config.py
@@ -22,3 +22,5 @@ TYPE_CLASSICATION = "classification"
 TYPE_OBJECT_DETECTION = "object-detection"
 TYPE_INSTANCE_SEGMENTATION = "instance-segmentation"
 TYPE_SEMANTIC_SEGMENTATION = "semantic-segmentation"
+
+DEFAULT_BATCH_NAME = "Pip Package Upload"

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -144,7 +144,7 @@ class Project:
 
         # If image is not a hosted image
         if not hosted_image:
-            batch_name = batch_name if batch_name and isinstance(batch_name, str) else "Pip Package Upload1"
+            batch_name = batch_name if batch_name and isinstance(batch_name, str) else "Pip Package Upload"
 
             project_name = self.id.rsplit("/")[1]
             image_name = os.path.basename(image_path)

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -10,7 +10,7 @@ import requests
 from PIL import Image, UnidentifiedImageError
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
-from roboflow.config import API_URL, DEMO_KEYS
+from roboflow.config import API_URL, DEFAULT_BATCH_NAME, DEMO_KEYS
 from roboflow.core.version import Version
 
 ACCEPTED_IMAGE_FORMATS = ["PNG", "JPEG"]
@@ -140,7 +140,7 @@ class Project:
         image_path,
         hosted_image=False,
         split="train",
-        batch_name="Pip Package Upload",
+        batch_name=DEFAULT_BATCH_NAME,
     ):
         """function to upload image to the specific project
         :param image_path: path to image you'd like to upload.
@@ -153,7 +153,7 @@ class Project:
             batch_name = (
                 batch_name
                 if batch_name and isinstance(batch_name, str)
-                else "Pip Package Upload"
+                else DEFAULT_BATCH_NAME
             )
 
             project_name = self.id.rsplit("/")[1]
@@ -258,7 +258,7 @@ class Project:
         image_id=None,
         split="train",
         num_retry_uploads=0,
-        batch_name="Pip Package Upload",
+        batch_name=DEFAULT_BATCH_NAME,
     ):
 
         """upload function
@@ -329,7 +329,7 @@ class Project:
         image_id=None,
         split="train",
         num_retry_uploads=0,
-        batch_name="Pip Package Upload",
+        batch_name=DEFAULT_BATCH_NAME,
     ):
 
         success = False

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -144,6 +144,7 @@ class Project:
 
         # If image is not a hosted image
         if not hosted_image:
+            batch_name = batch_name if batch_name and isinstance(batch_name, str) else "Pip Package Upload1"
 
             project_name = self.id.rsplit("/")[1]
             image_name = os.path.basename(image_path)

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -135,7 +135,13 @@ class Project:
 
         raise RuntimeError("Version number {} is not found.".format(version_number))
 
-    def __image_upload(self, image_path, hosted_image=False, split="train", batch_name="Pip Package Upload"):
+    def __image_upload(
+        self,
+        image_path,
+        hosted_image=False,
+        split="train",
+        batch_name="Pip Package Upload",
+    ):
         """function to upload image to the specific project
         :param image_path: path to image you'd like to upload.
         :param hosted_image: if the image is hosted online, then this should be modified
@@ -144,7 +150,11 @@ class Project:
 
         # If image is not a hosted image
         if not hosted_image:
-            batch_name = batch_name if batch_name and isinstance(batch_name, str) else "Pip Package Upload"
+            batch_name = (
+                batch_name
+                if batch_name and isinstance(batch_name, str)
+                else "Pip Package Upload"
+            )
 
             project_name = self.id.rsplit("/")[1]
             image_name = os.path.basename(image_path)
@@ -158,7 +168,7 @@ class Project:
                     "?api_key=",
                     self.__api_key,
                     "&batch=",
-                    batch_name
+                    batch_name,
                 ]
             )
 
@@ -248,7 +258,7 @@ class Project:
         image_id=None,
         split="train",
         num_retry_uploads=0,
-        batch_name="Pip Package Upload"
+        batch_name="Pip Package Upload",
     ):
 
         """upload function
@@ -290,7 +300,7 @@ class Project:
                 image_id=image_id,
                 split=split,
                 num_retry_uploads=num_retry_uploads,
-                batch_name=batch_name
+                batch_name=batch_name,
             )
         else:
             images = os.listdir(image_path)
@@ -304,7 +314,7 @@ class Project:
                         image_id=image_id,
                         split=split,
                         num_retry_uploads=num_retry_uploads,
-                        batch_name=batch_name
+                        batch_name=batch_name,
                     )
                     print("[ " + path + " ] was uploaded succesfully.")
                 else:
@@ -319,7 +329,7 @@ class Project:
         image_id=None,
         split="train",
         num_retry_uploads=0,
-        batch_name="Pip Package Upload"
+        batch_name="Pip Package Upload",
     ):
 
         success = False
@@ -328,7 +338,10 @@ class Project:
         if image_path is not None:
             # Upload Image Response
             response = self.__image_upload(
-                image_path, hosted_image=hosted_image, split=split, batch_name=batch_name
+                image_path,
+                hosted_image=hosted_image,
+                split=split,
+                batch_name=batch_name,
             )
             # Get JSON response values
             try:

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -135,7 +135,7 @@ class Project:
 
         raise RuntimeError("Version number {} is not found.".format(version_number))
 
-    def __image_upload(self, image_path, hosted_image=False, split="train"):
+    def __image_upload(self, image_path, hosted_image=False, split="train", batch_name="Pip Package Upload"):
         """function to upload image to the specific project
         :param image_path: path to image you'd like to upload.
         :param hosted_image: if the image is hosted online, then this should be modified
@@ -156,6 +156,8 @@ class Project:
                     "/upload",
                     "?api_key=",
                     self.__api_key,
+                    "&batch=",
+                    batch_name
                 ]
             )
 
@@ -245,6 +247,7 @@ class Project:
         image_id=None,
         split="train",
         num_retry_uploads=0,
+        batch_name="Pip Package Upload"
     ):
 
         """upload function
@@ -286,6 +289,7 @@ class Project:
                 image_id=image_id,
                 split=split,
                 num_retry_uploads=num_retry_uploads,
+                batch_name=batch_name
             )
         else:
             images = os.listdir(image_path)
@@ -299,6 +303,7 @@ class Project:
                         image_id=image_id,
                         split=split,
                         num_retry_uploads=num_retry_uploads,
+                        batch_name=batch_name
                     )
                     print("[ " + path + " ] was uploaded succesfully.")
                 else:
@@ -313,6 +318,7 @@ class Project:
         image_id=None,
         split="train",
         num_retry_uploads=0,
+        batch_name="Pip Package Upload"
     ):
 
         success = False
@@ -321,7 +327,7 @@ class Project:
         if image_path is not None:
             # Upload Image Response
             response = self.__image_upload(
-                image_path, hosted_image=hosted_image, split=split
+                image_path, hosted_image=hosted_image, split=split, batch_name=batch_name
             )
             # Get JSON response values
             try:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="roboflow",  # Replace with your own username
-    version="0.2.15",
+    version="0.2.16",
     author="Roboflow",
     author_email="jacob@roboflow.com",
     description="python client for the Roboflow application",
@@ -32,7 +32,6 @@ setuptools.setup(
         "requests_toolbelt",
         "six",
         "urllib3==1.26.6",
-        "wget",
         "tqdm>=4.41.0",
         "PyYAML>=5.3.1",
         "wget",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,7 @@ import unittest
 import responses
 
 import roboflow
-from roboflow.config import API_URL
+from roboflow.config import API_URL, DEFAULT_BATCH_NAME
 
 ROBOFLOW_API_KEY = "my-test-app"
 WORKSPACE_NAME = "my-workspace"
@@ -92,7 +92,7 @@ class RoboflowTest(unittest.TestCase):
         # Upload image
         responses.add(
             responses.POST,
-            f"{API_URL}/dataset/{PROJECT_NAME}/upload?api_key={ROBOFLOW_API_KEY}",
+            f"{API_URL}/dataset/{PROJECT_NAME}/upload?api_key={ROBOFLOW_API_KEY}&batch={DEFAULT_BATCH_NAME}",
             json={'duplicate': True, 'id': 'hbALkCFdNr9rssgOUXug'},
             status=200
         )


### PR DESCRIPTION
# Description

Batch name was a parameter added to the upload api which allows users to specify a specific bucket to upload to. See batch upload info in docs (pending push).

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

We did not make a test / unit case file, but we tested the following edge cases:
- batch name not specified, `project.upload("test.jpg")`
- batch name with empty string provided, `project.upload("test.jpg", batch_name="")`
- batch name with None, `project.upload("test.jpg", batch_name=None)`
- batch name with number, `project.upload("test.jpg", batch_name=1)`

## Any specific deployment considerations

will need to update the docs pip package section.

## Docs

-   [x] Docs updated? What were the changes: added batch info to docs for typical `curl` command but not for pip commands
