### PR TITLE
Windows Support for Python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
         "cycler==0.10.0",
         "glob2",
         "idna==2.10",
-        "kiwisolver==1.3.1",
+        "kiwisolver==1.4.3",
         "matplotlib",
         "numpy>=1.18.5",
         "opencv-python-headless>=4.5.1.48",


### PR DESCRIPTION
Pre-built wheels for that version are available for Windows Users this reduces the need to install Visual C++ Tools to build kiwisolver. Tested on Python 3.10

# Description

Please include a summary of the change and which issue is fixed or implemented. Please also include relevant motivation and context (e.g. links, docs, tickets etc.).

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
