### PR TITLE
kiwisolver support for Python 3.10.x and other versions relaxed.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ certifi==2021.5.30
 chardet==4.0.0
 cycler==0.10.0
 idna==2.10
-kiwisolver==1.3.1
+kiwisolver==1.4.3
 matplotlib
 numpy>=1.18.5
 opencv-python>=4.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ certifi==2021.5.30
 chardet==4.0.0
 cycler==0.10.0
 idna==2.10
-kiwisolver==1.4.3
+kiwisolver>=1.3.1
 matplotlib
 numpy>=1.18.5
 opencv-python>=4.1.2

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
         "cycler==0.10.0",
         "glob2",
         "idna==2.10",
-        "kiwisolver==1.3.1",
+        "kiwisolver==1.4.3",
         "matplotlib",
         "numpy>=1.18.5",
         "opencv-python-headless>=4.5.1.48",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
         "cycler==0.10.0",
         "glob2",
         "idna==2.10",
-        "kiwisolver==1.4.3",
+        "kiwisolver>=1.3.1",
         "matplotlib",
         "numpy>=1.18.5",
         "opencv-python-headless>=4.5.1.48",


### PR DESCRIPTION
# Description

I've noticed that on certain versions of  `python` in my case `3.10.7` kiwisolver build was failing as it required C++ 14.0 or greater build tools, that is unacceptable as this should be a simple install. So I've relaxed the kiwisolver dependencies a bit. 

List any dependencies that are required for this change.
`kiwisolver>=1.3.1` (instead of kiwisolver==1.3.1)
## Type of change

Please delete options that are not relevant.

-   [ x ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Relaxed kiwisolver would help ease install for Windows users. 
YOUR_ANSWER

## Any specific deployment considerations

None

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
