### PR TITLE
Add simple version.export() functionality and clean up version.download() a bit

### DIFF
--- a/roboflow/core/dataset.py
+++ b/roboflow/core/dataset.py
@@ -1,6 +1,6 @@
 class Dataset:
     def __init__(self, name, version, model_format, location):
         self.name = name
-        self.name = version
+        self.version = version
         self.model_format = model_format
         self.location = location

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -109,7 +109,7 @@ class Version:
             link = "https://app.roboflow.com/ds/n9QwXwUK42?key=NnVCe2yMxP"
         else:
             url = self.__get_download_url(model_format)
-            resp = requests.get(url, params={'api_key': self.__api_key })
+            resp = requests.get(url, params={"api_key": self.__api_key})
             if resp.status_code == 200:
                 link = resp.json()["export"]["link"]
             else:
@@ -134,7 +134,7 @@ class Version:
         :raises RuntimeError / HTTPError:
         """
         url = self.__get_download_url(model_format)
-        response = requests.post(url, params={'api_key': self.__api_key })
+        response = requests.post(url, params={"api_key": self.__api_key})
         if not response.ok:
             try:
                 raise RuntimeError(response.json())
@@ -153,6 +153,7 @@ class Version:
 
         :return None:
         """
+
         def bar_progress(current, total, width=80):
             progress_message = (
                 "Downloading Dataset Version Zip in "
@@ -186,7 +187,7 @@ class Version:
                 try:
                     zip_ref.extract(member, location)
                 except zipfile.error:
-                    raise RuntimeError('Error unzipping download')
+                    raise RuntimeError("Error unzipping download")
 
         os.remove(location + "/roboflow.zip")
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,26 @@
+from roboflow.config import TYPE_OBJECT_DETECTION
+from roboflow.core.version import Version
+
+
+def get_version(api_key="test-api-key", project_name="Test Project Name", version_number="1", type=TYPE_OBJECT_DETECTION, **kwargs):
+    version_data = {
+        "id": f"test-workspace/test-project/2",
+        "name": "augmented-416x416",
+        "created": 1663104679.539,
+        "images": 240,
+        "splits": {"train": 210, "test": 10, "valid": 20},
+        "preprocessing": {"resize": {"height": "416", "enabled": True, "width": "416", "format": "Stretch to"}, "auto-orient": {"enabled": True}},
+        "augmentation": {"blur": {"enabled": True, "pixels": 1.5}, "image": {"enabled": True, "versions": 3}, "rotate": {"degrees": 15, "enabled": True}, "crop": {"enabled": True, "percent": 40, "min": 0}, "flip": {"horizontal": True, "enabled": True, "vertical": False}},
+        "exports": []
+    }
+    version_data.update(kwargs)
+
+    return Version(
+                version_data,
+                type,
+                api_key,
+                project_name,
+                version_number,
+                model_format=None,
+                local=None,
+            )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -5,10 +5,10 @@ class TestProject(RoboflowTest):
 
     def test_check_valid_image_with_accepted_formats(self):
         images_to_test = [
-          'rabbit.JPG',
-          'rabbit2.jpg',
-          'hand-rabbit.PNG',
-          'woodland-rabbit.png',
+            'rabbit.JPG',
+            'rabbit2.jpg',
+            'hand-rabbit.PNG',
+            'woodland-rabbit.png',
         ]
 
         for image in images_to_test:
@@ -16,8 +16,8 @@ class TestProject(RoboflowTest):
 
     def test_check_valid_image_with_unaccepted_formats(self):
         images_to_test = [
-          'sky-rabbit.gif',
-          'sky-rabbit.heic',
+            'sky-rabbit.gif',
+            'sky-rabbit.heic',
         ]
 
         for image in images_to_test:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,104 @@
+import os
+from sys import intern
+
+import requests
+import responses
+import unittest
+from unittest.mock import patch
+
+from .helpers import get_version
+
+
+class TestVersion(unittest.TestCase):
+
+    def setUp(self):
+        super(TestVersion, self).setUp()
+        self.version = get_version(project_name="Test Dataset", id="test-workspace/test-project/2", version_number="3")
+
+    def test_get_download_location_with_env_variable(self):
+        with patch.dict(os.environ, { "DATASET_DIRECTORY": "/my/exports"}, clear=True):
+
+            # This is a weird python thing to get access to the private function for testing.
+            __get_download_location = self.version._Version__get_download_location
+            location = __get_download_location()
+            self.assertEqual(location, "/my/exports/Test-Dataset-3")
+
+    def test_get_download_location_without_env_variable(self):
+        # This is a weird python thing to get access to the private function for testing.
+        __get_download_location = self.version._Version__get_download_location
+        location = __get_download_location()
+        self.assertEqual(location, "Test-Dataset-3")
+
+    def test_get_download_url(self):
+        # This is a weird python thing to get access to the private function for testing.
+        __get_download_url = self.version._Version__get_download_url
+        url = __get_download_url("yolo1337")
+        self.assertEqual(url, "https://api.roboflow.com/test-workspace/test-project/3/yolo1337")
+
+    def test_download_with_location_overwrites_location(self):
+        pass
+
+    def test_download_without_format_raises_error(self):
+        with self.assertRaises(RuntimeError):
+            self.version.download()
+
+    @responses.activate
+    def test_export_returns_true_on_api_success(self):
+        version = get_version(project_name="Test Dataset", id="test-workspace/test-project/2", version_number="4")
+        api_url = f"https://api.roboflow.com/test-workspace/test-project/4/test-format"
+        responses.add(responses.POST, api_url, status=204)
+        
+        export = version.export("test-format")
+        request = responses.calls[0].request
+
+        self.assertTrue(export)
+        self.assertEqual(request.method, "POST")
+        self.assertRegex(request.url, rf"^{api_url}")
+        self.assertDictEqual(request.params, { "api_key": "test-api-key" })
+
+    @responses.activate
+    def test_export_raises_error_on_bad_request(self):
+        version = get_version(project_name="Test Dataset", id="test-workspace/test-project/2", version_number="4")
+        api_url = f"https://api.roboflow.com/test-workspace/test-project/4/test-format"
+        responses.add(responses.POST, api_url, status=400, json={ "error": "BROKEN!!"})
+        
+        with self.assertRaises(RuntimeError):
+            version.export("test-format")
+
+    @responses.activate
+    def test_export_raises_error_on_api_failure(self):
+        version = get_version(project_name="Test Dataset", id="test-workspace/test-project/2", version_number="4")
+        api_url = f"https://api.roboflow.com/test-workspace/test-project/4/test-format"
+        responses.add(responses.POST, api_url, status=500)
+        
+        with self.assertRaises(requests.exceptions.HTTPError):
+            version.export("test-format")
+
+class TestGetFormatIdentifier(unittest.TestCase):
+    def setUp(self):
+        super(TestGetFormatIdentifier, self).setUp()
+        self.version = get_version(project_name="Test Dataset", id="test-workspace/test-project/2", version_number="3")
+
+        # This is a weird python thing to get access to the private function for testing.
+        self.get_format_identifier = self.version._Version__get_format_identifier
+
+    def test_returns_simple_format(self):
+        self.assertEqual(self.get_format_identifier("coco"), "coco")
+
+    def test_returns_friendly_names_for_supported_formats(self):
+        formats = [("yolov5", "yolov5pytorch"), ("yolov7", "yolov7pytorch")]
+        for external_format, internal_format in formats:
+            self.assertEqual(self.get_format_identifier(external_format), internal_format)
+
+    def test_falls_back_to_instance_variable_if_model_format_is_none(self):
+        self.version.model_format = "fallback"
+        self.assertEqual(self.get_format_identifier(None), "fallback")
+
+    def test_falls_back_to_instance_variable_if_model_format_is_none_and_converts_human_readable_format_to_identifier(self):
+        self.version.model_format = "yolov5"
+        self.assertEqual(self.get_format_identifier(None), "yolov5pytorch")
+
+    def test_raises_runtime_error_if_model_format_is_none(self):
+        self.version.model_format = None
+        with self.assertRaises(RuntimeError):
+            self.get_format_identifier(None)


### PR DESCRIPTION
# Description

While adding `Version.export()`, and thinking about how that could be integrated into `Version.download()`, I decided to also clean that method up a bit to make it more parseable and testable. I think I also fixed a couple bugs in the process (and hopefully didn't introduce any 😅)

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

I've only tested with the new unit tests so far. We should definitely manually test. I'd love to pair on that.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
