### PR TITLE
added edge case handling for conditional object

### DIFF
--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -12,7 +12,6 @@ from roboflow.util.active_learning_utils import (
     count_comparisons,
 )
 
-
 class Workspace:
     def __init__(self, info, api_key, default_workspace, model_format):
         if api_key in DEMO_KEYS:
@@ -90,6 +89,17 @@ class Workspace:
             upload_destination: str = name of the upload project
             conditionals: dict = dictionary of upload conditions
         """
+
+
+        # ensure that all fields of conditionals have a key:value pair
+
+        conditionals["target_classes"] = [] if "target_classes" not in conditionals else conditionals["target_classes"]
+        conditionals["confidence_interval"] = [30,99] if "confidence_interval" not in conditionals else conditionals["confidence_interval"]
+        conditionals["required_class_variance_count"] = 1 if "required_class_variance_count" not in conditionals else conditionals["required_class_variance_count"]
+        conditionals["required_objects_count"] = 1 if "required_objects_count" not in conditionals else conditionals["required_objects_count"]
+        conditionals["required_class_count"] = 0 if "required_class_count" not in conditionals else conditionals["required_class_count"]
+        conditionals["minimum_size_requirement"] = float('-inf') if "minimum_size_requirement" not in conditionals else conditionals["minimum_size_requirement"]
+        conditionals["maximum_size_requirement"] = float('inf')  if "maximum_size_requirement" not in conditionals else conditionals["maximum_size_requirement"]
 
         inference_model = (
             self.project(inference_endpoint[0]).version(inference_endpoint[1]).model

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -12,6 +12,7 @@ from roboflow.util.active_learning_utils import (
     count_comparisons,
 )
 
+
 class Workspace:
     def __init__(self, info, api_key, default_workspace, model_format):
         if api_key in DEMO_KEYS:
@@ -90,16 +91,43 @@ class Workspace:
             conditionals: dict = dictionary of upload conditions
         """
 
-
         # ensure that all fields of conditionals have a key:value pair
 
-        conditionals["target_classes"] = [] if "target_classes" not in conditionals else conditionals["target_classes"]
-        conditionals["confidence_interval"] = [30,99] if "confidence_interval" not in conditionals else conditionals["confidence_interval"]
-        conditionals["required_class_variance_count"] = 1 if "required_class_variance_count" not in conditionals else conditionals["required_class_variance_count"]
-        conditionals["required_objects_count"] = 1 if "required_objects_count" not in conditionals else conditionals["required_objects_count"]
-        conditionals["required_class_count"] = 0 if "required_class_count" not in conditionals else conditionals["required_class_count"]
-        conditionals["minimum_size_requirement"] = float('-inf') if "minimum_size_requirement" not in conditionals else conditionals["minimum_size_requirement"]
-        conditionals["maximum_size_requirement"] = float('inf')  if "maximum_size_requirement" not in conditionals else conditionals["maximum_size_requirement"]
+        conditionals["target_classes"] = (
+            []
+            if "target_classes" not in conditionals
+            else conditionals["target_classes"]
+        )
+        conditionals["confidence_interval"] = (
+            [30, 99]
+            if "confidence_interval" not in conditionals
+            else conditionals["confidence_interval"]
+        )
+        conditionals["required_class_variance_count"] = (
+            1
+            if "required_class_variance_count" not in conditionals
+            else conditionals["required_class_variance_count"]
+        )
+        conditionals["required_objects_count"] = (
+            1
+            if "required_objects_count" not in conditionals
+            else conditionals["required_objects_count"]
+        )
+        conditionals["required_class_count"] = (
+            0
+            if "required_class_count" not in conditionals
+            else conditionals["required_class_count"]
+        )
+        conditionals["minimum_size_requirement"] = (
+            float("-inf")
+            if "minimum_size_requirement" not in conditionals
+            else conditionals["minimum_size_requirement"]
+        )
+        conditionals["maximum_size_requirement"] = (
+            float("inf")
+            if "maximum_size_requirement" not in conditionals
+            else conditionals["maximum_size_requirement"]
+        )
 
         inference_model = (
             self.project(inference_endpoint[0]).version(inference_endpoint[1]).model


### PR DESCRIPTION
# Description

Users were previously required to use all conditions for active learning so added edge case handling to the `conditionals` object in case users don't specify all possible key words.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Ran a series of unit tests with the below code snippet making sure all variations were supported including no config object, one field, all fields, some fields, `value == None`, etc.

```
from roboflow import Roboflow

rf = Roboflow(api_key="BLlkFnwfSaRFUXBfU0tJ")

upload_conditions_config = {
    "target_classes": ['helmet'],
    "confidence_interval": [30,90]
}

rf.workspace().active_learning("./test_cases", ".png", ["hard-hat-universe-0dy7t", 3], "merge_tester", upload_conditions_config)
```

## Docs

-   [x] Docs updated? What were the changes: Added a note in the active learning section that you don't have to use all fields.
