### PR TITLE
Switch github action target branch from master to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,10 @@
 name: Test WorkFlow
 
 on:
+  push:
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -119,9 +119,7 @@ class Version:
         self.__extract_zip(location, model_format)
         self.__reformat_yaml(location, model_format)
 
-        return Dataset(
-            self.name, self.version, model_format, os.path.abspath(location)
-        )
+        return Dataset(self.name, self.version, model_format, os.path.abspath(location))
 
     def export(self, model_format=None):
         """


### PR DESCRIPTION
# Description

Github actions were not being run after renaming the base branch from `master` to `main`. This should fix that.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

I opened this PR and saw that the actions are working again.