### PR TITLE
Clip compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,21 @@ python -m unittest
 
 ### Code Quality
 
+When creating new functions, please follow the [Google style Python docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html). See example below:
+```
+def example_function(param1: int, param2: str) -> bool:
+    """Example function that does something.
+
+    Args:
+        param1: The first parameter.
+        param2: The second parameter.
+
+    Returns:
+        The return value. True for success, False otherwise.
+
+    """
+```
+
 We provide a `Makefile` to format and ensure code quality. **Be sure to run them before creating a PR**.
 
 ```

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -11,7 +11,6 @@ from roboflow.util.active_learning_utils import (
     clip_encode,
     count_comparisons,
 )
-
 from roboflow.util.clip_compare_utils import clip_encode
 
 
@@ -82,7 +81,7 @@ class Workspace:
             dir: (str) = name reference to a directory of images for comparison
             image_ext: (str) = file format for expected images (don't include the . before the file type name)
             target_image: (str) = name reference for target image to compare individual images from directory against
-                
+
             returns: (dict) = a key:value mapping of image_name:comparison_score_to_target
         """
 
@@ -95,15 +94,14 @@ class Workspace:
 
         # grab all images in a given directory with ext type
         for image in glob.glob(f"./{dir}/*{image_ext}"):
-            # compare image 
+            # compare image
             similarity = clip_encode(image, target_image)
 
             # map image name to similarity score
-            comparisons.append({image:similarity})
+            comparisons.append({image: similarity})
 
         # TODO - sort all comparisons to find best matches?
         return comparisons
-
 
     def active_learning(
         self,

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -78,7 +78,7 @@ class Workspace:
 
     def clip_compare(
         self, dir: str = "", image_ext: str = ".png", target_image: str = ""
-    ) -> dict[str, float]:
+    ) -> dict:
         """
         @params:
             dir: (str) = name reference to a directory of images for comparison

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -97,7 +97,6 @@ def clip_compare(self, dir: str = "", image_ext: str = ".png", target_image: str
             similarity = clip_encode(image, target_image)
             # map image name to similarity score
             comparisons.append({image: similarity})
-
         # TODO - sort all comparisons to find best matches?
         return comparisons
 

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -12,6 +12,8 @@ from roboflow.util.active_learning_utils import (
     count_comparisons,
 )
 
+from roboflow.util.clip_compare_utils import clip_encode
+
 
 class Workspace:
     def __init__(self, info, api_key, default_workspace, model_format):
@@ -73,6 +75,35 @@ class Workspace:
         dataset_info = dataset_info.json()["project"]
 
         return Project(self.__api_key, dataset_info, self.model_format)
+
+    def clip_compare(self, dir="", image_ext=".png", target_image=""):
+        """
+        @params:
+            dir: (str) = name reference to a directory of images for comparison
+            image_ext: (str) = file format for expected images (don't include the . before the file type name)
+            target_image: (str) = name reference for target image to compare individual images from directory against
+                
+            returns: (dict) = a key:value mapping of image_name:comparison_score_to_target
+        """
+
+        assert isinstance(dir, str), "valid directory string required!"
+        assert isinstance(image_ext, str), "valid image ext string required!"
+        assert isinstance(target_image, str), "valid target image string required!"
+
+        # list to store comparison results in
+        comparisons = []
+
+        # grab all images in a given directory with ext type
+        for image in glob.glob(f"./{dir}/*{image_ext}"):
+            # compare image 
+            similarity = clip_encode(image, target_image)
+
+            # map image name to similarity score
+            comparisons.append({image:similarity})
+
+        # TODO - sort all comparisons to find best matches?
+        return comparisons
+
 
     def active_learning(
         self,

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -1,6 +1,7 @@
 import glob
 import json
 import sys
+from PIL import Image
 
 import requests
 
@@ -75,7 +76,9 @@ class Workspace:
 
         return Project(self.__api_key, dataset_info, self.model_format)
 
-def clip_compare(self, dir: str = "", image_ext: str = ".png", target_image: str = "") -> Dict[str, float]:
+    def clip_compare(
+        self, dir: str = "", image_ext: str = ".png", target_image: str = ""
+    ) -> dict[str, float]:
         """
         @params:
             dir: (str) = name reference to a directory of images for comparison
@@ -85,10 +88,6 @@ def clip_compare(self, dir: str = "", image_ext: str = ".png", target_image: str
             returns: (dict) = a key:value mapping of image_name:comparison_score_to_target
         """
 
-        assert isinstance(dir, str), "valid directory string required!"
-        assert isinstance(image_ext, str), "valid image ext string required!"
-        assert isinstance(target_image, str), "valid target image string required!"
-
         # list to store comparison results in
         comparisons = []
         # grab all images in a given directory with ext type
@@ -97,7 +96,7 @@ def clip_compare(self, dir: str = "", image_ext: str = ".png", target_image: str
             similarity = clip_encode(image, target_image)
             # map image name to similarity score
             comparisons.append({image: similarity})
-comparisons = sorted(comparisons, key=lambda item: -list(item.values())[0])
+            comparisons = sorted(comparisons, key=lambda item: -list(item.values())[0])
         return comparisons
 
     def active_learning(

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -95,7 +95,6 @@ def clip_compare(self, dir: str = "", image_ext: str = ".png", target_image: str
         for image in glob.glob(f"./{dir}/*{image_ext}"):
             # compare image
             similarity = clip_encode(image, target_image)
-
             # map image name to similarity score
             comparisons.append({image: similarity})
 

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -97,7 +97,7 @@ def clip_compare(self, dir: str = "", image_ext: str = ".png", target_image: str
             similarity = clip_encode(image, target_image)
             # map image name to similarity score
             comparisons.append({image: similarity})
-        # TODO - sort all comparisons to find best matches?
+comparisons = sorted(comparisons, key=lambda item: -list(item.values())[0])
         return comparisons
 
     def active_learning(

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -1,9 +1,9 @@
 import glob
 import json
 import sys
-from PIL import Image
 
 import requests
+from PIL import Image
 
 from roboflow.config import API_URL, CLIP_FEATURIZE_URL, DEMO_KEYS
 from roboflow.core.project import Project

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -91,7 +91,6 @@ def clip_compare(self, dir: str = "", image_ext: str = ".png", target_image: str
 
         # list to store comparison results in
         comparisons = []
-
         # grab all images in a given directory with ext type
         for image in glob.glob(f"./{dir}/*{image_ext}"):
             # compare image

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -75,7 +75,7 @@ class Workspace:
 
         return Project(self.__api_key, dataset_info, self.model_format)
 
-    def clip_compare(self, dir="", image_ext=".png", target_image=""):
+def clip_compare(self, dir: str = "", image_ext: str = ".png", target_image: str = "") -> Dict[str, float]:
         """
         @params:
             dir: (str) = name reference to a directory of images for comparison

--- a/roboflow/util/clip_compare_utils.py
+++ b/roboflow/util/clip_compare_utils.py
@@ -1,0 +1,50 @@
+import glob
+import json
+import base64, io
+
+import requests
+from PIL import Image
+
+# rf.predict requires images formatted and base64 encoded
+def base64_encode(image_path):
+    """
+    @params:
+        iamge_path: (str) = name reference to a given image for encoding
+
+    returns: a base64 encoded string formatted for travel to an HTTP endpoint
+    """
+    
+    image = Image.open(image_path)
+    buffered = io.BytesIO()
+    image_rgb = image.convert("RGB")
+    image_rgb.save(buffered, quality=90, format="JPEG")
+    img_str = base64.b64encode(buffered.getvalue())
+    return img_str.decode("ascii")
+
+# base64 encode two images and send them to the clip endpoint for further encoding and comparison
+def clip_encode(image1, image2):
+    """
+    @params:
+        image1: (str) = name referenceto a given image for encoding
+        image2: (str) = name referenceto a given image for encoding
+
+        returns: (float) = a value between 1 and 0, with 1 being images were identical
+    """
+    image1 = base64_encode(image1)
+    image2 = base64_encode(image2)
+
+    url = 'https://clip-featurize-double-image-li37nwjfaq-uc.a.run.app/predict'
+    headers = {
+        "Content-Type": "text/plain"
+    }
+    data = json.dumps({
+        "image1": image1,
+        "image2": image2
+    })
+
+    r = requests.post(url,
+                    data=data,
+                    headers=headers
+    )
+
+    return float(r.json()["similarity"])

--- a/roboflow/util/clip_compare_utils.py
+++ b/roboflow/util/clip_compare_utils.py
@@ -10,7 +10,7 @@ from roboflow.config import CLIP_FEATURIZE_URL
 
 
 def base64_encode(image_path):
-""" `rf.predict` requires images formatted and base64 encoded
+    """`rf.predict` requires images formatted and base64 encoded
     @params:
         iamge_path: (str) = name reference to a given image for encoding
 
@@ -26,10 +26,8 @@ def base64_encode(image_path):
 
 
 def clip_encode(image1: str, image2: str) -> float:
-    """
-""" This function base64 encodes two images and send them to the clip endpoint for further encoding and comparison
-
-@params 
+    """This function base64 encodes two images and send them to the clip endpoint for further encoding and comparison
+    @params
 
         image1: (str) = name referenceto a given image for encoding
         image2: (str) = name referenceto a given image for encoding
@@ -38,7 +36,6 @@ def clip_encode(image1: str, image2: str) -> float:
     """
     image1 = base64_encode(image1)
     image2 = base64_encode(image2)
-
 
     headers = {"Content-Type": "text/plain"}
     data = json.dumps({"image1": image1, "image2": image2})

--- a/roboflow/util/clip_compare_utils.py
+++ b/roboflow/util/clip_compare_utils.py
@@ -9,7 +9,6 @@ from PIL import Image
 from roboflow.config import CLIP_FEATURIZE_URL
 
 
-# rf.predict requires images formatted and base64 encoded
 def base64_encode(image_path):
     """
     @params:

--- a/roboflow/util/clip_compare_utils.py
+++ b/roboflow/util/clip_compare_utils.py
@@ -25,7 +25,6 @@ def base64_encode(image_path):
     return img_str.decode("ascii")
 
 
-# base64 encode two images and send them to the clip endpoint for further encoding and comparison
 def clip_encode(image1, image2):
     """
     @params:

--- a/roboflow/util/clip_compare_utils.py
+++ b/roboflow/util/clip_compare_utils.py
@@ -39,7 +39,6 @@ def clip_encode(image1: str, image2: str) -> float:
     image1 = base64_encode(image1)
     image2 = base64_encode(image2)
 
-    url = CLIP_FEATURIZE_URL
 
     headers = {"Content-Type": "text/plain"}
     data = json.dumps({"image1": image1, "image2": image2})

--- a/roboflow/util/clip_compare_utils.py
+++ b/roboflow/util/clip_compare_utils.py
@@ -43,6 +43,6 @@ def clip_encode(image1: str, image2: str) -> float:
     headers = {"Content-Type": "text/plain"}
     data = json.dumps({"image1": image1, "image2": image2})
 
-    r = requests.post(url, data=data, headers=headers)
+    r = requests.post(CLIP_FEATURIZE_URL, data=data, headers=headers)
 
     return float(r.json()["similarity"])

--- a/roboflow/util/clip_compare_utils.py
+++ b/roboflow/util/clip_compare_utils.py
@@ -1,11 +1,13 @@
+import base64
 import glob
+import io
 import json
-import base64, io
 
 import requests
 from PIL import Image
 
 from roboflow.config import CLIP_FEATURIZE_URL
+
 
 # rf.predict requires images formatted and base64 encoded
 def base64_encode(image_path):
@@ -15,13 +17,14 @@ def base64_encode(image_path):
 
     returns: a base64 encoded string formatted for travel to an HTTP endpoint
     """
-    
+
     image = Image.open(image_path)
     buffered = io.BytesIO()
     image_rgb = image.convert("RGB")
     image_rgb.save(buffered, quality=90, format="JPEG")
     img_str = base64.b64encode(buffered.getvalue())
     return img_str.decode("ascii")
+
 
 # base64 encode two images and send them to the clip endpoint for further encoding and comparison
 def clip_encode(image1, image2):
@@ -36,18 +39,10 @@ def clip_encode(image1, image2):
     image2 = base64_encode(image2)
 
     url = CLIP_FEATURIZE_URL
-    
-    headers = {
-        "Content-Type": "text/plain"
-    }
-    data = json.dumps({
-        "image1": image1,
-        "image2": image2
-    })
 
-    r = requests.post(url,
-                    data=data,
-                    headers=headers
-    )
+    headers = {"Content-Type": "text/plain"}
+    data = json.dumps({"image1": image1, "image2": image2})
+
+    r = requests.post(url, data=data, headers=headers)
 
     return float(r.json()["similarity"])

--- a/roboflow/util/clip_compare_utils.py
+++ b/roboflow/util/clip_compare_utils.py
@@ -27,7 +27,10 @@ def base64_encode(image_path):
 
 def clip_encode(image1: str, image2: str) -> float:
     """
-    @params:
+""" This function base64 encodes two images and send them to the clip endpoint for further encoding and comparison
+
+@params 
+
         image1: (str) = name referenceto a given image for encoding
         image2: (str) = name referenceto a given image for encoding
 

--- a/roboflow/util/clip_compare_utils.py
+++ b/roboflow/util/clip_compare_utils.py
@@ -25,7 +25,7 @@ def base64_encode(image_path):
     return img_str.decode("ascii")
 
 
-def clip_encode(image1, image2):
+def clip_encode(image1: str, image2: str) -> float:
     """
     @params:
         image1: (str) = name referenceto a given image for encoding

--- a/roboflow/util/clip_compare_utils.py
+++ b/roboflow/util/clip_compare_utils.py
@@ -5,6 +5,8 @@ import base64, io
 import requests
 from PIL import Image
 
+from roboflow.config import CLIP_FEATURIZE_URL
+
 # rf.predict requires images formatted and base64 encoded
 def base64_encode(image_path):
     """
@@ -33,7 +35,8 @@ def clip_encode(image1, image2):
     image1 = base64_encode(image1)
     image2 = base64_encode(image2)
 
-    url = 'https://clip-featurize-double-image-li37nwjfaq-uc.a.run.app/predict'
+    url = CLIP_FEATURIZE_URL
+    
     headers = {
         "Content-Type": "text/plain"
     }

--- a/roboflow/util/clip_compare_utils.py
+++ b/roboflow/util/clip_compare_utils.py
@@ -10,7 +10,7 @@ from roboflow.config import CLIP_FEATURIZE_URL
 
 
 def base64_encode(image_path):
-    """
+""" `rf.predict` requires images formatted and base64 encoded
     @params:
         iamge_path: (str) = name reference to a given image for encoding
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     ],
     packages=find_packages(exclude=("tests",)),
     extras_require={
-        "dev": ["flake8", "black==22.3.0", "isort", "responses"],
+        "dev": ["flake8", "black==22.3.0", "isort", "responses","twine"],
     },
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
# Description

Given a `dir` of images and a `target` image, perform CLIP encoding and similarity comparison using our hosted CLIP backend (uses cosine similarity method) and returns an object mapping each image's similarity score from the `dir` to the `target` image. 

No required dependencies that weren't already in there. I added `twine` to the list of `dev` packages as we use twine to update the hosted package up in the pypi store.

You must specify the following URL in `config.py` as the env variable `CLIP_FEATURIZE_URL`, `'https://clip-featurize-double-image-li37nwjfaq-uc.a.run.app/predict'`, to hit the endpoint as this endpoint does not have auth / usage tracking.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

I had a directory of images and a target image that I ran the script against. Checked for the following edge cases and added `assert` statements as needed`:
- no image or directory string provided (including `None` type)
- image or directory provided but doesn't exist (handled by built-in pillow exceptions)


YOUR_ANSWER

## Any specific deployment considerations

Can't think of any.

## Docs

-   [ ] Docs updated? What were the changes: will not update docs until endpoint gets auth / usage tracking. Instead will be providing Walmart the URL directly with instructions on how to use the pip package accordingly (as per Brad's suggestion).
