### PR TITLE
OpenCV Image Encoder

### DIFF
--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -147,7 +147,7 @@ class ObjectDetectionModel:
 
                 # Create buffer
                 buffered = io.BytesIO()
-                image.save(buffered, quality=90, format="JPEG")
+                image.save(buffered, format="PNG")
                 # Base64 encode image
                 img_str = base64.b64encode(buffered.getvalue())
                 img_str = img_str.decode("ascii")

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -3,8 +3,8 @@ import io
 import json
 import os
 import urllib
-import cv2
 
+import cv2
 import requests
 from PIL import Image
 
@@ -133,7 +133,7 @@ class ObjectDetectionModel:
             stroke=stroke,
             labels=labels,
         )
-        
+
         # Check if image exists at specified path or URL or is an array
         if hasattr(image_path, "__len__") == True:
             pass
@@ -142,7 +142,7 @@ class ObjectDetectionModel:
 
         # If image is local image
         if not hosted:
-            if ".jpg" in image_path or ".png" in image_path: # Open Image in RGB Format
+            if ".jpg" in image_path or ".png" in image_path:  # Open Image in RGB Format
                 image = Image.open(image_path).convert("RGB")
 
                 # Create buffer
@@ -160,7 +160,7 @@ class ObjectDetectionModel:
                 )
             else:
                 # Performing inference on a OpenCV2 frame
-                retval, buffer = cv2.imencode('.jpg', image_path)
+                retval, buffer = cv2.imencode(".jpg", image_path)
                 img_str = base64.b64encode(buffer)
                 # print(img_str)
                 img_str = img_str.decode("ascii")
@@ -192,7 +192,9 @@ class ObjectDetectionModel:
     def __exception_check(self, image_path_check=None):
         # Check if Image path exists exception check (for both hosted URL and local image)
         if image_path_check is not None:
-            if not os.path.exists(image_path_check) and not check_image_url(image_path_check):
+            if not os.path.exists(image_path_check) and not check_image_url(
+                image_path_check
+            ):
                 raise Exception("Image does not exist at " + image_path_check + "!")
 
     def __generate_url(


### PR DESCRIPTION
# Description

We added cv2 to our package list because we want to use it for image encoding. This allows us to bypass saving an image locally and might save inference time.

I added some logic to fix when an end user tried to send an OpenCV frame array. Previously the logic would crash and we provided a statement to ensure that doesn't happen for frame array data.

## List any dependencies that are required for this change.

import cv2

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested on multiple webcam and resolutions.

Still passes images paths and image URLs just fine.

## Any specific deployment considerations

Not sure the size of the cv2 package, but it is something to consider. Probably worth storage space if it speeds up inference logic.

## Docs

-   [ ] Docs updated? 

What were the changes: Docs have currently not been updated, but I will when change goes into effect. Will add example of using OpenCV2 frame data in model.predict()