### PR TITLE
Local active learning

### DIFF
--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -96,9 +96,10 @@ class Project:
             version_array.append(version_object)
         return version_array
 
-    def version(self, version_number):
+    def version(self, version_number, local=None):
         """Retrieves information about a specific version, and throws it into an object.
         :param version_number: the version number that you want to retrieve
+        :local: specifies the localhost address and port if pointing towards local inference engine
         :return Version() object
         """
 
@@ -133,7 +134,7 @@ class Project:
                     self.name,
                     current_version_num,
                     self.model_format,
-                    local=None,
+                    local=local,
                     workspace=self.__workspace,
                     project=self.__project_name,
                 )

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -280,12 +280,13 @@ class Workspace:
         )
 
         # check if inference_model references endpoint or local
-        if use_localhost == True:
-            inference_model = f"http://localhost:9001/{inference_endpoint[0]}/{inference_endpoint[1]}?api_key={self.__api_key}"
-        else:
-            inference_model = (
-                self.project(inference_endpoint[0]).version(inference_endpoint[1]).model
-            )
+        local = "http://localhost:9001/" if use_localhost else None
+
+        inference_model = (
+            self.project(inference_endpoint[0])
+            .version(version_number=inference_endpoint[1], local=local)
+            .model
+        )
         upload_project = self.project(upload_destination)
 
         print("inference reference point: ", inference_model)

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -224,19 +224,21 @@ class Workspace:
 
     def active_learning(
         self,
-        raw_data_location,
-        raw_data_extension,
-        inference_endpoint,
-        upload_destination,
-        conditionals,
-    ):
-        """
+        raw_data_location: str = "",
+        raw_data_extension: str = "",
+        inference_endpoint: list = [],
+        upload_destination: str = "",
+        conditionals: dict = {},
+        use_localhost: bool = False,
+    ) -> str:
+        """perform inference on each image in directory and upload based on conditions
         @params:
-            raw_data_location: dir = folder of frames to be processed
-            raw_data_extension: extension of frames to be processed
-            inference_endpoint: List[str, int] = name of the project
-            upload_destination: str = name of the upload project
-            conditionals: dict = dictionary of upload conditions
+            raw_data_location: (str) = folder of frames to be processed
+            raw_data_extension: (str) = extension of frames to be processed
+            inference_endpoint: (List[str, int]) = name of the project
+            upload_destination: (str) = name of the upload project
+            conditionals: (dict) = dictionary of upload conditions
+            use_localhost: (bool) = determines if local http format used or remote endpoint
         """
 
         # ensure that all fields of conditionals have a key:value pair
@@ -277,9 +279,13 @@ class Workspace:
             else conditionals["maximum_size_requirement"]
         )
 
-        inference_model = (
-            self.project(inference_endpoint[0]).version(inference_endpoint[1]).model
-        )
+        # check if inference_model references endpoint or local
+        if use_localhost == True:
+            inference_model = f"http://localhost:9001/{inference_endpoint[0]}/{inference_endpoint[1]}?api_key={self.__api_key}"
+        else:
+            inference_model = (
+                self.project(inference_endpoint[0]).version(inference_endpoint[1]).model
+            )
         upload_project = self.project(upload_destination)
 
         print("inference reference point: ", inference_model)
@@ -365,7 +371,7 @@ class Workspace:
                     upload_project.upload(image, num_retry_uploads=3)
                     break
 
-        return
+        return "complete"
 
     def __str__(self):
         projects = self.projects()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="roboflow",  # Replace with your own username
-    version="0.2.20",
+    version="0.2.21",
     author="Roboflow",
     author_email="jacob@roboflow.com",
     description="python client for the Roboflow application",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="roboflow",  # Replace with your own username
-    version="0.2.19",
+    version="0.2.20",
     author="Roboflow",
     author_email="jacob@roboflow.com",
     description="python client for the Roboflow application",


### PR DESCRIPTION
# Description

Updated `Version` so users can specify a locally running inference server within the pip package.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Test code:
```
from roboflow import Roboflow

rf = Roboflow(api_key="BLlkFnwfSaRFUXBfU0tJ")

model_name = "hard-hat-universe-0dy7t"
model_number = 17
upload_img_directory = "./"
image_extention_type = ".png"
project_upload_destation = "merge_tester"

conditionals = {
    "required_objects_count" : 1,
    "required_class_count": 1,
    "target_classes": [],
    "minimum_size_requirement" : float('-inf'),
    "maximum_size_requirement" : float('inf'),
    "confidence_interval" : [10,90],
}

rf.workspace().active_learning(upload_img_directory, image_extention_type, [model_name, model_number], project_upload_destation, conditionals, True)
```

Tested edge cases:
- provide `True` and inference server is up
- provide `True` and inference server is down
- provide `False` and inference server is up

## Any specific deployment considerations

Tested with Cobravision and oak devices in mind but tested on several servers.

## Docs

-   [ ] Docs updated? What were the changes: Will update docs for active learning and general inference via local server when merged.
