### PR TITLE
removed check for extensions, PIL will do that for us

### DIFF
--- a/roboflow/config.py
+++ b/roboflow/config.py
@@ -14,6 +14,9 @@ INSTANCE_SEGMENTATION_URL = os.getenv(
 SEMANTIC_SEGMENTATION_URL = os.getenv(
     "SEMANTIC_SEGMENTATION_URL", "https://segment.roboflow.com"
 )
+OBJECT_DETECTION_URL = os.getenv(
+    "SEMANTIC_SEGMENTATION_URL", "https://detect.roboflow.com"
+)
 
 CLIP_FEATURIZE_URL = os.getenv("CLIP_FEATURIZE_URL", "CLIP FEATURIZE URL NOT IN ENV")
 OCR_URL = os.getenv("OCR_URL", "OCR URL NOT IN ENV")

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -6,13 +6,14 @@ import urllib
 from pathlib import Path
 
 import cv2
+import numpy as np
 import requests
 from PIL import Image
 
 from roboflow.config import OBJECT_DETECTION_MODEL
 from roboflow.util.image_utils import check_image_url
 from roboflow.util.prediction import PredictionGroup
-import numpy as np
+
 
 class ObjectDetectionModel:
     def __init__(

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -12,7 +12,7 @@ from PIL import Image
 from roboflow.config import OBJECT_DETECTION_MODEL
 from roboflow.util.image_utils import check_image_url
 from roboflow.util.prediction import PredictionGroup
-
+import numpy as np
 
 class ObjectDetectionModel:
     def __init__(
@@ -157,7 +157,7 @@ class ObjectDetectionModel:
                     data=img_str,
                     headers={"Content-Type": "application/x-www-form-urlencoded"},
                 )
-            else:
+            elif isinstance(image_path, np.ndarray):
                 # Performing inference on a OpenCV2 frame
                 retval, buffer = cv2.imencode(".jpg", image_path)
                 img_str = base64.b64encode(buffer)
@@ -168,6 +168,8 @@ class ObjectDetectionModel:
                     data=img_str,
                     headers={"Content-Type": "application/x-www-form-urlencoded"},
                 )
+            else:
+                raise ValueError("image_path must be a string or a numpy array.")
         else:
             # Create API URL for hosted image (slightly different)
             self.api_url += "&image=" + urllib.parse.quote_plus(image_path)

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -143,20 +143,31 @@ class ObjectDetectionModel:
 
         # If image is local image
         if not hosted:
-            image = Image.open(image_path).convert("RGB")
-            # Create buffer
-            buffered = io.BytesIO()
-            image.save(buffered, format="PNG")
-            # Base64 encode image
-            img_str = base64.b64encode(buffered.getvalue())
-            img_str = img_str.decode("ascii")
-            # Post to API and return response
-            resp = requests.post(
-                self.api_url,
-                data=img_str,
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-            )
-
+            if type(image_path) is str:
+                image = Image.open(image_path).convert("RGB")
+                # Create buffer
+                buffered = io.BytesIO()
+                image.save(buffered, format="PNG")
+                # Base64 encode image
+                img_str = base64.b64encode(buffered.getvalue())
+                img_str = img_str.decode("ascii")
+                # Post to API and return response
+                resp = requests.post(
+                    self.api_url,
+                    data=img_str,
+                    headers={"Content-Type": "application/x-www-form-urlencoded"},
+                )
+            else:
+                # Performing inference on a OpenCV2 frame
+                retval, buffer = cv2.imencode(".jpg", image_path)
+                img_str = base64.b64encode(buffer)
+                # print(img_str)
+                img_str = img_str.decode("ascii")
+                resp = requests.post(
+                    self.api_url,
+                    data=img_str,
+                    headers={"Content-Type": "application/x-www-form-urlencoded"},
+                )
         else:
             # Create API URL for hosted image (slightly different)
             self.api_url += "&image=" + urllib.parse.quote_plus(image_path)

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -177,8 +177,7 @@ class ObjectDetectionModel:
             # POST to the API
             resp = requests.get(self.api_url)
 
-        if resp.status_code != 200:
-            raise Exception(resp.text)
+        resp.raise_for_status()
         # Return a prediction group if JSON data
         if self.format == "json":
             return PredictionGroup.create_prediction_group(

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -3,6 +3,7 @@ import io
 import json
 import os
 import urllib
+from pathlib import Path
 
 import cv2
 import requests
@@ -140,35 +141,23 @@ class ObjectDetectionModel:
         else:
             self.__exception_check(image_path_check=image_path)
 
+        is_local_image = Path(image_path).exists()
+        print(is_local_image)
         # If image is local image
         if not hosted:
-            if ".jpg" in image_path or ".png" in image_path:  # Open Image in RGB Format
-                image = Image.open(image_path).convert("RGB")
-
-                # Create buffer
-                buffered = io.BytesIO()
-                image.save(buffered, format="PNG")
-                # Base64 encode image
-                img_str = base64.b64encode(buffered.getvalue())
-                img_str = img_str.decode("ascii")
-
-                # Post to API and return response
-                resp = requests.post(
-                    self.api_url,
-                    data=img_str,
-                    headers={"Content-Type": "application/x-www-form-urlencoded"},
-                )
-            else:
-                # Performing inference on a OpenCV2 frame
-                retval, buffer = cv2.imencode(".jpg", image_path)
-                img_str = base64.b64encode(buffer)
-                # print(img_str)
-                img_str = img_str.decode("ascii")
-                resp = requests.post(
-                    self.api_url,
-                    data=img_str,
-                    headers={"Content-Type": "application/x-www-form-urlencoded"},
-                )
+            image = Image.open(image_path).convert("RGB")
+            # Create buffer
+            buffered = io.BytesIO()
+            image.save(buffered, format="PNG")
+            # Base64 encode image
+            img_str = base64.b64encode(buffered.getvalue())
+            img_str = img_str.decode("ascii")
+            # Post to API and return response
+            resp = requests.post(
+                self.api_url,
+                data=img_str,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
 
         else:
             # Create API URL for hosted image (slightly different)

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -141,8 +141,6 @@ class ObjectDetectionModel:
         else:
             self.__exception_check(image_path_check=image_path)
 
-        is_local_image = Path(image_path).exists()
-        print(is_local_image)
         # If image is local image
         if not hosted:
             image = Image.open(image_path).convert("RGB")

--- a/roboflow/util/clip_compare_utils.py
+++ b/roboflow/util/clip_compare_utils.py
@@ -1,5 +1,4 @@
 import base64
-import glob
 import io
 import json
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -33,7 +33,6 @@ unittest.defaultTestLoader.sortTestMethodsUsing = compare
 
 
 class RoboflowTest(unittest.TestCase):
-
     def setUp(self):
         super(RoboflowTest, self).setUp()
         responses.start()
@@ -46,9 +45,9 @@ class RoboflowTest(unittest.TestCase):
                 "welcome": "Welcome to the Roboflow API.",
                 "instructions": "You are successfully authenticated.",
                 "docs": "https://docs.roboflow.com",
-                "workspace": WORKSPACE_NAME
+                "workspace": WORKSPACE_NAME,
             },
-            status=200
+            status=200,
         )
 
         # Get workspace
@@ -56,16 +55,34 @@ class RoboflowTest(unittest.TestCase):
             responses.GET,
             f"{API_URL}/{WORKSPACE_NAME}?api_key={ROBOFLOW_API_KEY}",
             json={
-                'workspace': {
-                    'name': WORKSPACE_NAME,
-                    'url': WORKSPACE_NAME,
-                    'members': 1,
-                    'projects': [
-                        {'id': f'{WORKSPACE_NAME}/{PROJECT_NAME}', 'type': 'object-detection', 'name': 'Hard Hat Sample', 'created': 1593802673.521, 'updated': 1663269501.654, 'images': 100, 'unannotated': 3, 'annotation': 'Workers', 'versions': 2, 'public': False, 'splits': {'train': 70, 'test': 10, 'valid': 20}, 'colors': {'head': '#8622FF', 'person': '#FF00FF', 'helmet': '#C7FC00'}, 'classes': {'person': 9, 'helmet': 287, 'head': 90}}
-                    ]
+                "workspace": {
+                    "name": WORKSPACE_NAME,
+                    "url": WORKSPACE_NAME,
+                    "members": 1,
+                    "projects": [
+                        {
+                            "id": f"{WORKSPACE_NAME}/{PROJECT_NAME}",
+                            "type": "object-detection",
+                            "name": "Hard Hat Sample",
+                            "created": 1593802673.521,
+                            "updated": 1663269501.654,
+                            "images": 100,
+                            "unannotated": 3,
+                            "annotation": "Workers",
+                            "versions": 2,
+                            "public": False,
+                            "splits": {"train": 70, "test": 10, "valid": 20},
+                            "colors": {
+                                "head": "#8622FF",
+                                "person": "#FF00FF",
+                                "helmet": "#C7FC00",
+                            },
+                            "classes": {"person": 9, "helmet": 287, "head": 90},
+                        }
+                    ],
                 }
             },
-            status=200
+            status=200,
         )
 
         # Get project
@@ -73,28 +90,80 @@ class RoboflowTest(unittest.TestCase):
             responses.GET,
             f"{API_URL}/{WORKSPACE_NAME}/{PROJECT_NAME}?api_key={ROBOFLOW_API_KEY}",
             json={
-                'workspace': {
-                    'name': WORKSPACE_NAME,
-                    'url': WORKSPACE_NAME,
-                    'members': 1
+                "workspace": {
+                    "name": WORKSPACE_NAME,
+                    "url": WORKSPACE_NAME,
+                    "members": 1,
                 },
-                'project': {
-                    'id': f'{WORKSPACE_NAME}/{PROJECT_NAME}', 'type': 'object-detection', 'name': 'Hard Hat Sample', 'created': 1593802673.521, 'updated': 1663269501.654, 'images': 100, 'unannotated': 3, 'annotation': 'Workers', 'versions': 2, 'public': False, 'splits': {'test': 10, 'train': 70, 'valid': 20}, 'colors': {'person': '#FF00FF', 'helmet': '#C7FC00', 'head': '#8622FF'}, 'classes': {'person': 9, 'helmet': 287, 'head': 90}
+                "project": {
+                    "id": f"{WORKSPACE_NAME}/{PROJECT_NAME}",
+                    "type": "object-detection",
+                    "name": "Hard Hat Sample",
+                    "created": 1593802673.521,
+                    "updated": 1663269501.654,
+                    "images": 100,
+                    "unannotated": 3,
+                    "annotation": "Workers",
+                    "versions": 2,
+                    "public": False,
+                    "splits": {"test": 10, "train": 70, "valid": 20},
+                    "colors": {
+                        "person": "#FF00FF",
+                        "helmet": "#C7FC00",
+                        "head": "#8622FF",
+                    },
+                    "classes": {"person": 9, "helmet": 287, "head": 90},
                 },
-                'versions': [
-                    {'id': f'{WORKSPACE_NAME}/{PROJECT_NAME}/2', 'name': 'augmented-416x416', 'created': 1663104679.539, 'images': 240, 'splits': {'train': 210, 'test': 10, 'valid': 20}, 'preprocessing': {'resize': {'height': '416', 'enabled': True, 'width': '416', 'format': 'Stretch to'}, 'auto-orient': {'enabled': True}}, 'augmentation': {'blur': {'enabled': True, 'pixels': 1.5}, 'image': {'enabled': True, 'versions': 3}, 'rotate': {'degrees': 15, 'enabled': True}, 'crop': {'enabled': True, 'percent': 40, 'min': 0}, 'flip': {'horizontal': True, 'enabled': True, 'vertical': False}}, 'exports': []},
-                    {'id': f'{WORKSPACE_NAME}/{PROJECT_NAME}/1', 'name': 'raw', 'created': 1663104679.538, 'images': 100, 'splits': {'train': 70, 'test': 10, 'valid': 20}, 'preprocessing': {}, 'augmentation': {}, 'exports': []}
-                ]
+                "versions": [
+                    {
+                        "id": f"{WORKSPACE_NAME}/{PROJECT_NAME}/2",
+                        "name": "augmented-416x416",
+                        "created": 1663104679.539,
+                        "images": 240,
+                        "splits": {"train": 210, "test": 10, "valid": 20},
+                        "preprocessing": {
+                            "resize": {
+                                "height": "416",
+                                "enabled": True,
+                                "width": "416",
+                                "format": "Stretch to",
+                            },
+                            "auto-orient": {"enabled": True},
+                        },
+                        "augmentation": {
+                            "blur": {"enabled": True, "pixels": 1.5},
+                            "image": {"enabled": True, "versions": 3},
+                            "rotate": {"degrees": 15, "enabled": True},
+                            "crop": {"enabled": True, "percent": 40, "min": 0},
+                            "flip": {
+                                "horizontal": True,
+                                "enabled": True,
+                                "vertical": False,
+                            },
+                        },
+                        "exports": [],
+                    },
+                    {
+                        "id": f"{WORKSPACE_NAME}/{PROJECT_NAME}/1",
+                        "name": "raw",
+                        "created": 1663104679.538,
+                        "images": 100,
+                        "splits": {"train": 70, "test": 10, "valid": 20},
+                        "preprocessing": {},
+                        "augmentation": {},
+                        "exports": [],
+                    },
+                ],
             },
-            status=200
+            status=200,
         )
 
         # Upload image
         responses.add(
             responses.POST,
             f"{API_URL}/dataset/{PROJECT_NAME}/upload?api_key={ROBOFLOW_API_KEY}&batch={DEFAULT_BATCH_NAME}",
-            json={'duplicate': True, 'id': 'hbALkCFdNr9rssgOUXug'},
-            status=200
+            json={"duplicate": True, "id": "hbALkCFdNr9rssgOUXug"},
+            status=200,
         )
 
         self.connect_to_roboflow()

--- a/tests/models/test_instance_segmentation.py
+++ b/tests/models/test_instance_segmentation.py
@@ -18,19 +18,10 @@ MOCK_RESPONSE = {
             "class": "J",
             "confidence": 0.598,
             "points": [
-                {
-                    "x": 831.0,
-                    "y": 527.0
-                },
-                {
-                    "x": 931.0,
-                    "y": 389.0
-                },
-                {
-                    "x": 831.0,
-                    "y": 527.0
-                }
-            ]
+                {"x": 831.0, "y": 527.0},
+                {"x": 931.0, "y": 389.0},
+                {"x": 831.0, "y": 527.0},
+            ],
         },
         {
             "x": 363.8,
@@ -40,26 +31,13 @@ MOCK_RESPONSE = {
             "class": "K",
             "confidence": 0.52,
             "points": [
-                {
-                    "x": 131.0,
-                    "y": 999.0
-                },
-                {
-                    "x": 269.0,
-                    "y": 666.0
-                },
-
-                {
-                    "x": 131.0,
-                    "y": 999.0
-                }
-            ]
-        }
+                {"x": 131.0, "y": 999.0},
+                {"x": 269.0, "y": 666.0},
+                {"x": 131.0, "y": 999.0},
+            ],
+        },
     ],
-    "image": {
-        "width": 1333,
-        "height": 1000
-    }
+    "image": {"width": 1333, "height": 1000},
 }
 
 
@@ -85,7 +63,10 @@ class TestInstanceSegmentation(unittest.TestCase):
         instance = InstanceSegmentationModel(self.api_key, self.version_id)
 
         self.assertEqual(instance.id, self.version_id)
-        self.assertEqual(instance.api_url, f"{INSTANCE_SEGMENTATION_URL}/{self.dataset_id}/{self.version}")
+        self.assertEqual(
+            instance.api_url,
+            f"{INSTANCE_SEGMENTATION_URL}/{self.dataset_id}/{self.version}",
+        )
 
     @responses.activate
     def test_predict_returns_prediction_group(self):
@@ -109,7 +90,7 @@ class TestInstanceSegmentation(unittest.TestCase):
 
         request = responses.calls[0].request
 
-        self.assertEqual(request.method, 'POST')
+        self.assertEqual(request.method, "POST")
         self.assertRegex(request.url, rf"^{self.api_url}")
         self.assertDictEqual(request.params, self._default_params)
         self.assertIsNotNone(request.body)
@@ -131,7 +112,7 @@ class TestInstanceSegmentation(unittest.TestCase):
 
         request = responses.calls[1].request
 
-        self.assertEqual(request.method, 'POST')
+        self.assertEqual(request.method, "POST")
         self.assertRegex(request.url, rf"^{self.api_url}")
         self.assertDictEqual(request.params, expected_params)
         self.assertIsNone(request.body)
@@ -140,10 +121,7 @@ class TestInstanceSegmentation(unittest.TestCase):
     def test_predict_with_confidence_request(self):
         confidence = "100"
         image_path = "tests/images/rabbit.JPG"
-        expected_params = {
-            **self._default_params,
-            "confidence": confidence
-        }
+        expected_params = {**self._default_params, "confidence": confidence}
         instance = InstanceSegmentationModel(self.api_key, self.version_id)
 
         responses.add(responses.POST, self.api_url, json=MOCK_RESPONSE)
@@ -152,7 +130,7 @@ class TestInstanceSegmentation(unittest.TestCase):
 
         request = responses.calls[0].request
 
-        self.assertEqual(request.method, 'POST')
+        self.assertEqual(request.method, "POST")
         self.assertRegex(request.url, rf"^{self.api_url}")
         self.assertDictEqual(request.params, expected_params)
         self.assertIsNotNone(request.body)

--- a/tests/models/test_object_detection.py
+++ b/tests/models/test_object_detection.py
@@ -1,0 +1,164 @@
+import unittest
+
+from requests.exceptions import HTTPError
+import responses
+
+from roboflow.config import OBJECT_DETECTION_URL
+from roboflow.models.object_detection import ObjectDetectionModel
+from roboflow.util.prediction import PredictionGroup
+
+from PIL import UnidentifiedImageError
+import numpy as np
+
+MOCK_RESPONSE = {
+    "predictions": [
+        {
+            "x": 189.5,
+            "y": 100,
+            "width": 163,
+            "height": 186,
+            "class": "helmet",
+            "confidence": 0.544,
+        }
+    ],
+    "image": {"width": 2048, "height": 1371},
+}
+
+
+class TestObjectDetection(unittest.TestCase):
+
+    api_key = "my-api-key"
+    workspace = "roboflow"
+    dataset_id = "test-123"
+    version = "23"
+
+    api_url = f"{OBJECT_DETECTION_URL}/{dataset_id}/{version}"
+
+    _default_params = {
+        "api_key": api_key,
+        "confidence": "40",
+        "format": "json",
+        "labels": "false",
+        "name": "YOUR_IMAGE.jpg",
+        "overlap": "30",
+        "stroke": "1",
+    }
+
+    def setUp(self):
+        super(TestObjectDetection, self).setUp()
+        self.version_id = f"{self.workspace}/{self.dataset_id}/{self.version}"
+
+    def test_init_sets_attributes(self):
+        instance = ObjectDetectionModel(
+            self.api_key, self.version_id, version=self.version
+        )
+
+        self.assertEqual(instance.id, self.version_id)
+        # self.assertEqual(instance.api_url, f"{OBJECT_DETECTION_URL}/{self.dataset_id}/{self.version}")
+
+    @responses.activate
+    def test_predict_returns_prediction_group(self):
+        print(self.api_url)
+        image_path = "tests/images/rabbit.JPG"
+        instance = ObjectDetectionModel(
+            self.api_key, self.version_id, version=self.version
+        )
+
+        responses.add(responses.POST, self.api_url, json=MOCK_RESPONSE)
+
+        group = instance.predict(image_path)
+
+        self.assertIsInstance(group, PredictionGroup)
+
+    @responses.activate
+    def test_predict_with_local_image_request(self):
+        image_path = "tests/images/rabbit.JPG"
+        instance = ObjectDetectionModel(
+            self.api_key, self.version_id, version=self.version
+        )
+
+        responses.add(responses.POST, self.api_url, json=MOCK_RESPONSE)
+
+        instance.predict(image_path)
+
+        request = responses.calls[0].request
+
+        self.assertEqual(request.method, "POST")
+        self.assertRegex(request.url, rf"^{self.api_url}")
+        self.assertDictEqual(request.params, self._default_params)
+        self.assertIsNotNone(request.body)
+
+    @responses.activate
+    def test_predict_with_a_numpy_array_request(self):
+        np_array = np.ones((100,100,1), dtype=np.uint8)
+        instance = ObjectDetectionModel(
+            self.api_key, self.version_id, version=self.version
+        )
+
+        responses.add(responses.POST, self.api_url, json=MOCK_RESPONSE)
+
+        instance.predict(np_array)
+
+        request = responses.calls[0].request
+
+        self.assertEqual(request.method, "POST")
+        self.assertRegex(request.url, rf"^{self.api_url}")
+        self.assertDictEqual(request.params, self._default_params)
+        self.assertIsNotNone(request.body)
+    
+    def test_predict_with_local_wrong_image_request(self):
+        image_path = "tests/images/not_an_image.txt"
+        instance = ObjectDetectionModel(
+            self.api_key, self.version_id, version=self.version
+        )
+        self.assertRaises(UnidentifiedImageError, instance.predict, image_path)
+
+
+    @responses.activate
+    def test_predict_with_hosted_image_request(self):
+        image_path = "https://example.com/racoon.JPG"
+        expected_params = {
+            **self._default_params,
+            "image": image_path,
+        }
+        instance = ObjectDetectionModel(self.api_key, self.version_id,  version=self.version)
+
+        # Mock the library validating that the URL is valid before sending to the API
+        responses.add(responses.GET, self.api_url, json=MOCK_RESPONSE)
+
+        instance.predict(image_path, hosted=True)
+
+        request = responses.calls[0].request
+
+        self.assertEqual(request.method, "GET")
+        self.assertRegex(request.url, rf"^{self.api_url}")
+        self.assertDictEqual(request.params, expected_params)
+        self.assertIsNone(request.body)
+
+    @responses.activate
+    def test_predict_with_confidence_request(self):
+        confidence = "100"
+        image_path = "tests/images/rabbit.JPG"
+        expected_params = {**self._default_params, "confidence": confidence}
+        instance = ObjectDetectionModel(self.api_key, self.version_id, version=self.version)
+
+        responses.add(responses.POST, self.api_url, json=MOCK_RESPONSE)
+
+        instance.predict(image_path, confidence=confidence)
+
+        request = responses.calls[0].request
+
+        self.assertEqual(request.method, "POST")
+        self.assertRegex(request.url, rf"^{self.api_url}")
+        self.assertDictEqual(request.params, expected_params)
+        self.assertIsNotNone(request.body)
+
+    @responses.activate
+    def test_predict_with_non_200_response_raises_http_error(self):
+        image_path = "tests/images/rabbit.JPG"
+        responses.add(responses.POST, self.api_url, status=403)
+
+        instance = ObjectDetectionModel(self.api_key, self.version_id, version=self.version)
+
+        with self.assertRaises(HTTPError):
+            instance.predict(image_path)

--- a/tests/models/test_semantic_segmentation.py
+++ b/tests/models/test_semantic_segmentation.py
@@ -9,16 +9,9 @@ from roboflow.util.prediction import PredictionGroup
 
 
 MOCK_RESPONSE = {
-
     "segmentation_mask": "iVBORw0KGgoAAAANSUhEUgAAAgAAAAIACAAAAADRE4smAAACjElEQVR4nO3bzXKbMBiGUanT+79ldVHXwSmmFmJGfcU5i8SZbDR8DzL4pxQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgKXUOnsFTGX+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMuosxewklpKm72GXj9mLyBf/etBEgGMqqVGTv5BADcngEF151GSn7MXkO116HFXgMUOMCZ//gK4TuT8BTCkvfyKJICbE8CQ9vyRSgBDMm/9tgQwLHoDWCDhaWopj+nXkpuBHeBT9dtL/t9OndQzSQCf2j/Fa8mdfSlFAD3a3l+H20IAAXzszbN83fw3b/4COO9PEIFT3xDAeW2zJ6TeBHg7eEjLvgUsxQ4wrGXPXwDDoscvgHE1+ypQAGfU/U8CJpaQuObpvt4FeBy/9vIoigD6fR2z9nwZaPtyUBQB9Ds6ZnEFuAa4OQF0O9w043ZUAdxcXLGT/eN4xV0C2AH6LDd/AVwpcP4CuFDi/AVwocjrKQF0iTzJDwmgz3IFCKDTagUI4OYEcJ3IzUEAnSIv9Q/4VHCXd+NvsWGkrnum9xUE8hTQL3LQ7wjghJUKEMBlMrMQwBm7s868nMpc9X/iefB+fzc8cgtwGzjg8XWAyMFzOZspAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACwil+AQDJrnsYcnwAAAABJRU5ErkJggg==",
-    "class_map": {
-        "0": "background",
-        "1": "object"
-    },
-    "image": {
-        "width": 800,
-        "height": 600
-    }
+    "class_map": {"0": "background", "1": "object"},
+    "image": {"width": 800, "height": 600},
 }
 
 
@@ -30,7 +23,7 @@ class TestSemanticSegmentation(unittest.TestCase):
 
     api_url = f"https://segment.roboflow.com/{dataset_id}/{version}"
 
-    _default_params = { "api_key": api_key, "confidence": "50" }
+    _default_params = {"api_key": api_key, "confidence": "50"}
 
     version_id = f"{workspace}/{dataset_id}/{version}"
 
@@ -38,7 +31,10 @@ class TestSemanticSegmentation(unittest.TestCase):
         instance = SemanticSegmentationModel(self.api_key, self.version_id)
 
         self.assertEqual(instance.id, self.version_id)
-        self.assertEqual(instance.api_url, f"{SEMANTIC_SEGMENTATION_URL}/{self.dataset_id}/{self.version}")
+        self.assertEqual(
+            instance.api_url,
+            f"{SEMANTIC_SEGMENTATION_URL}/{self.dataset_id}/{self.version}",
+        )
 
     @responses.activate
     def test_predict_returns_prediction_group(self):
@@ -62,7 +58,7 @@ class TestSemanticSegmentation(unittest.TestCase):
 
         request = responses.calls[0].request
 
-        self.assertEqual(request.method, 'POST')
+        self.assertEqual(request.method, "POST")
         self.assertRegex(request.url, rf"^{self.api_url}")
         self.assertDictEqual(request.params, self._default_params)
         self.assertIsNotNone(request.body)
@@ -84,7 +80,7 @@ class TestSemanticSegmentation(unittest.TestCase):
 
         request = responses.calls[1].request
 
-        self.assertEqual(request.method, 'POST')
+        self.assertEqual(request.method, "POST")
         self.assertRegex(request.url, rf"^{self.api_url}")
         self.assertDictEqual(request.params, expected_params)
         self.assertIsNone(request.body)
@@ -93,10 +89,7 @@ class TestSemanticSegmentation(unittest.TestCase):
     def test_predict_with_confidence_request(self):
         confidence = "100"
         image_path = "tests/images/rabbit.JPG"
-        expected_params = {
-            **self._default_params,
-            "confidence": confidence
-        }
+        expected_params = {**self._default_params, "confidence": confidence}
         instance = SemanticSegmentationModel(self.api_key, self.version_id)
 
         responses.add(responses.POST, self.api_url, json=MOCK_RESPONSE)
@@ -105,7 +98,7 @@ class TestSemanticSegmentation(unittest.TestCase):
 
         request = responses.calls[0].request
 
-        self.assertEqual(request.method, 'POST')
+        self.assertEqual(request.method, "POST")
         self.assertRegex(request.url, rf"^{self.api_url}")
         self.assertDictEqual(request.params, expected_params)
         self.assertIsNotNone(request.body)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2,23 +2,22 @@ from . import RoboflowTest
 
 
 class TestProject(RoboflowTest):
-
     def test_check_valid_image_with_accepted_formats(self):
         images_to_test = [
-            'rabbit.JPG',
-            'rabbit2.jpg',
-            'hand-rabbit.PNG',
-            'woodland-rabbit.png',
+            "rabbit.JPG",
+            "rabbit2.jpg",
+            "hand-rabbit.PNG",
+            "woodland-rabbit.png",
         ]
 
         for image in images_to_test:
-            self.assertTrue(self.project.check_valid_image(f'tests/images/{image}'))
+            self.assertTrue(self.project.check_valid_image(f"tests/images/{image}"))
 
     def test_check_valid_image_with_unaccepted_formats(self):
         images_to_test = [
-            'sky-rabbit.gif',
-            'sky-rabbit.heic',
+            "sky-rabbit.gif",
+            "sky-rabbit.heic",
         ]
 
         for image in images_to_test:
-            self.assertFalse(self.project.check_valid_image(f'tests/images/{image}'))
+            self.assertFalse(self.project.check_valid_image(f"tests/images/{image}"))

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -12,7 +12,6 @@ from . import RoboflowTest, ordered, PROJECT_NAME
 
 
 class TestQueries(RoboflowTest):
-
     @ordered
     def test_workspace_fields(self):
         self.assertTrue(isinstance(self.workspace.name, str))

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -13,7 +13,11 @@ class TestDownload(unittest.TestCase):
     def setUp(self):
         super(TestDownload, self).setUp()
         self.api_url = "https://api.roboflow.com/test-workspace/test-project/4/coco"
-        self.version = get_version(project_name="Test Dataset", id="test-workspace/test-project/2", version_number="4")
+        self.version = get_version(
+            project_name="Test Dataset",
+            id="test-workspace/test-project/2",
+            version_number="4",
+        )
 
     @responses.activate
     def test_download_raises_exception_on_bad_request(self):
@@ -32,7 +36,7 @@ class TestDownload(unittest.TestCase):
     @patch.object(Version, "_Version__extract_zip")
     @patch.object(Version, "_Version__reformat_yaml")
     def test_download_returns_dataset(self, *_):
-        responses.add(responses.GET, self.api_url, json={"export": { "link": None }})
+        responses.add(responses.GET, self.api_url, json={"export": {"link": None}})
         dataset = self.version.download("coco", location="/my-spot")
         self.assertEqual(dataset.name, self.version.name)
         self.assertEqual(dataset.version, self.version.version)
@@ -41,35 +45,42 @@ class TestDownload(unittest.TestCase):
 
 
 class TestExport(unittest.TestCase):
-
     def setUp(self):
         super(TestExport, self).setUp()
-        self.api_url = "https://api.roboflow.com/test-workspace/test-project/4/test-format"
-        self.version = get_version(project_name="Test Dataset", id="test-workspace/test-project/2", version_number="4")
+        self.api_url = (
+            "https://api.roboflow.com/test-workspace/test-project/4/test-format"
+        )
+        self.version = get_version(
+            project_name="Test Dataset",
+            id="test-workspace/test-project/2",
+            version_number="4",
+        )
 
     @responses.activate
     def test_export_returns_true_on_api_success(self):
         responses.add(responses.POST, self.api_url, status=204)
-        
+
         export = self.version.export("test-format")
         request = responses.calls[0].request
 
         self.assertTrue(export)
         self.assertEqual(request.method, "POST")
         self.assertRegex(request.url, rf"^{self.api_url}")
-        self.assertDictEqual(request.params, { "api_key": "test-api-key" })
+        self.assertDictEqual(request.params, {"api_key": "test-api-key"})
 
     @responses.activate
     def test_export_raises_error_on_bad_request(self):
-        responses.add(responses.POST, self.api_url, status=400, json={ "error": "BROKEN!!"})
-        
+        responses.add(
+            responses.POST, self.api_url, status=400, json={"error": "BROKEN!!"}
+        )
+
         with self.assertRaises(RuntimeError):
             self.version.export("test-format")
 
     @responses.activate
     def test_export_raises_error_on_api_failure(self):
         responses.add(responses.POST, self.api_url, status=500)
-        
+
         with self.assertRaises(requests.exceptions.HTTPError):
             self.version.export("test-format")
 
@@ -78,13 +89,17 @@ class TestExport(unittest.TestCase):
 class TestGetDownloadLocation(unittest.TestCase):
     def setUp(self, *_):
         super(TestGetDownloadLocation, self).setUp()
-        self.version = get_version(project_name="Test Dataset", id="test-workspace/test-project/2", version_number="3")
+        self.version = get_version(
+            project_name="Test Dataset",
+            id="test-workspace/test-project/2",
+            version_number="3",
+        )
 
         # This is a weird python thing to get access to the private function for testing.
         self.get_download_location = self.version._Version__get_download_location
 
     def test_get_download_location_with_env_variable(self, *_):
-        with patch.dict(os.environ, { "DATASET_DIRECTORY": "/my/exports"}, clear=True):
+        with patch.dict(os.environ, {"DATASET_DIRECTORY": "/my/exports"}, clear=True):
             self.assertEqual(self.get_download_location(), "/my/exports/Test-Dataset-3")
 
     def test_get_download_location_without_env_variable(self, *_):
@@ -94,20 +109,30 @@ class TestGetDownloadLocation(unittest.TestCase):
 class TestGetDownloadURL(unittest.TestCase):
     def setUp(self):
         super(TestGetDownloadURL, self).setUp()
-        self.version = get_version(project_name="Test Dataset", id="test-workspace/test-project/2", version_number="3")
+        self.version = get_version(
+            project_name="Test Dataset",
+            id="test-workspace/test-project/2",
+            version_number="3",
+        )
 
         # This is a weird python thing to get access to the private function for testing.
         self.get_download_url = self.version._Version__get_download_url
 
     def test_get_download_url(self):
         url = self.get_download_url("yolo1337")
-        self.assertEqual(url, "https://api.roboflow.com/test-workspace/test-project/3/yolo1337")
+        self.assertEqual(
+            url, "https://api.roboflow.com/test-workspace/test-project/3/yolo1337"
+        )
 
 
 class TestGetFormatIdentifier(unittest.TestCase):
     def setUp(self):
         super(TestGetFormatIdentifier, self).setUp()
-        self.version = get_version(project_name="Test Dataset", id="test-workspace/test-project/2", version_number="3")
+        self.version = get_version(
+            project_name="Test Dataset",
+            id="test-workspace/test-project/2",
+            version_number="3",
+        )
 
         # This is a weird python thing to get access to the private function for testing.
         self.get_format_identifier = self.version._Version__get_format_identifier
@@ -118,13 +143,17 @@ class TestGetFormatIdentifier(unittest.TestCase):
     def test_returns_friendly_names_for_supported_formats(self):
         formats = [("yolov5", "yolov5pytorch"), ("yolov7", "yolov7pytorch")]
         for external_format, internal_format in formats:
-            self.assertEqual(self.get_format_identifier(external_format), internal_format)
+            self.assertEqual(
+                self.get_format_identifier(external_format), internal_format
+            )
 
     def test_falls_back_to_instance_variable_if_model_format_is_none(self):
         self.version.model_format = "fallback"
         self.assertEqual(self.get_format_identifier(None), "fallback")
 
-    def test_falls_back_to_instance_variable_if_model_format_is_none_and_converts_human_readable_format_to_identifier(self):
+    def test_falls_back_to_instance_variable_if_model_format_is_none_and_converts_human_readable_format_to_identifier(
+        self,
+    ):
         self.version.model_format = "yolov5"
         self.assertEqual(self.get_format_identifier(None), "yolov5pytorch")
 

--- a/tests/util/test_image_utils.py
+++ b/tests/util/test_image_utils.py
@@ -7,10 +7,10 @@ from roboflow.util.image_utils import check_image_path, check_image_url
 
 class TestCheckImagePath(unittest.TestCase):
     def test_valid_path(self):
-        self.assertTrue(check_image_path('tests/images/rabbit.JPG'))
-    
+        self.assertTrue(check_image_path("tests/images/rabbit.JPG"))
+
     def test_invalid_paths(self):
-        self.assertFalse(check_image_path('tests/images/notfound.jpg'))
+        self.assertFalse(check_image_path("tests/images/notfound.jpg"))
 
 
 class TestCheckImageURL(unittest.TestCase):
@@ -29,9 +29,7 @@ class TestCheckImageURL(unittest.TestCase):
         for path in paths:
             self.assertFalse(check_image_url(path))
 
-
     def test_url_not_found(self):
         url = "https://example.com/notfound.png"
         responses.add(responses.HEAD, url, status=404)
         self.assertFalse(check_image_url(url))
-    


### PR DESCRIPTION
# Description

Added checks for `image_path` type in `model.predict`, it can be either `str` or `np.array`. If it's a `str` we will use `PIL` to open it, otherwise `cv2.imencode` 

`PIL` will raise a `PIL.UnidentifiedImageError` error if it cannot load the image, e.g. sending a text file `photo.asd` returns in 

```
PIL.UnidentifiedImageError: cannot identify image file 'photo.asd'
```
Linked to #83 

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
